### PR TITLE
build-sys: fix python build dependencies

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -586,7 +586,7 @@ endif
 #
 
 if PYTHON_ENABLED
-python-bindings-build:
+python-bindings-build: libiot-glib.la libiot-common.la libiot-app.la
 	if test ! -f python/python-app-fw-wrapper.cpp; then \
 		d=$$(cd $(top_srcdir); pwd); \
 		ln -sf $$d/src/python/python-app-fw-wrapper.cpp python; \


### PR DESCRIPTION
Previously Python bindings build tried to link against shared objects
which were not necessarily built before them, causing bitbake build fail.

Signed-off-by: Topi Kuutela topi.kuutela@intel.com
